### PR TITLE
Use auth in repodiff.py

### DIFF
--- a/verification/repodiff.py
+++ b/verification/repodiff.py
@@ -218,9 +218,9 @@ if __name__ == '__main__':
     datalake_csv_local = 'data/repo-datalake-' + datestr + '.csv'
     github_csv = 'data/repo-github-' + datestr + '.csv'
     diff_file = 'data-verification/repodiff-' + datestr + '.csv'
-    diff_file_datalake = '/users/dmahugh/repodiff.csv'
+    diff_file_datalake = '/users/TabularSource2/repodiff.csv'
     logfile = 'data-verification/repodiff.log'
-    logfile_datalake = '/users/dmahugh/repodiff.log'
+    logfile_datalake = '/users/TabularSource2/repodiff.log'
 
     print_log(logfile,
               10*'-' + ' Data Verification for ' + datestr + ' ' + 10*'-')

--- a/verification/repodiff.py
+++ b/verification/repodiff.py
@@ -41,7 +41,8 @@ def github_data(*, endpoint=None, fields=None): #----------------------------<<<
     Returns a complete data set - if this endpoint does pagination, all pages
     are retrieved and aggregated.
     """
-    all_fields = github_allpages(endpoint=endpoint)
+    auth = (setting('ghinsights', 'github', 'username'), setting('ghinsights', 'github', 'pat'))
+    all_fields = github_allpages(endpoint=endpoint, auth=auth)
 
     # extract the requested fields and return them
     retval = []

--- a/verification/repodiff.py
+++ b/verification/repodiff.py
@@ -218,9 +218,9 @@ if __name__ == '__main__':
     datalake_csv_local = 'data/repo-datalake-' + datestr + '.csv'
     github_csv = 'data/repo-github-' + datestr + '.csv'
     diff_file = 'data-verification/repodiff-' + datestr + '.csv'
-    diff_file_datalake = '/users/TabularSource2/repodiff.csv'
+    diff_file_datalake = '/TabularSource2/repodiff.csv'
     logfile = 'data-verification/repodiff.log'
-    logfile_datalake = '/users/TabularSource2/repodiff.log'
+    logfile_datalake = '/TabularSource2/repodiff.log'
 
     print_log(logfile,
               10*'-' + ' Data Verification for ' + datestr + ' ' + 10*'-')


### PR DESCRIPTION
This change corrects private repos being invisible by repodiff.py script.
Before change:
```
2017-05-19 09:20:10.42 ---------- Data Verification for 2017-05-17 ----------
2017-05-19 09:20:18.38 Download Repo.csv from Data Lake .......   8.0 seconds, 8,245,731 bytes
2017-05-19 09:20:43.07 Get live data from GitHub API ..........  24.7 seconds, 220,848 bytes
2017-05-19 09:20:46.85 Generate repodiff-2017-05-17.csv .......   3.8 seconds, 229,115 bytes
2017-05-19 09:20:46.85                         Extra:     4,110 Repos
2017-05-19 09:20:49.40 Upload repodiff.csv to Data Lake .......   2.5 seconds
2017-05-19 09:20:49.40 Total elapsed time ---------------------  41.0 seconds
```
After change:
```
2017-05-19 09:47:51.49 ---------- Data Verification for 2017-05-17 ----------
2017-05-19 09:47:58.81 Download Repo.csv from Data Lake .......   7.3 seconds, 8,245,731 bytes
2017-05-19 09:49:16.65 Get live data from GitHub API ..........  77.8 seconds, 495,145 bytes
2017-05-19 09:49:21.88 Generate repodiff-2017-05-17.csv .......   5.2 seconds, 38,973 bytes
2017-05-19 09:49:21.88                         Missing:       6 Repos
2017-05-19 09:49:21.88                         Extra:       681 Repos
2017-05-19 09:49:24.20 Upload repodiff.csv to Data Lake .......   2.3 seconds
2017-05-19 09:49:24.20 Total elapsed time ---------------------  93.9 seconds
```